### PR TITLE
GitHub Actionsでのみビルドが転ぶ問題の調査

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
           lfs: true
       - uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "16"
           cache: "yarn"
       - name: install modules
         run: yarn install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
           lfs: true
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "14"
           cache: "yarn"
       - name: install modules
         run: yarn install

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,6 @@
 {
   "plugins": ["stylelint-order"],
-  "extends": ["stylelint-config-standard"],
+  "extends": ["stylelint-config-standard-scss"],
   "rules": {
     "at-rule-no-unknown": [
       true,
@@ -18,5 +18,5 @@
     "string-quotes": "single",
     "order/properties-alphabetical-order": true
   },
-  "ignoreFiles": ["**/node_modules/**", "/out/**", "/src/styles/**"]
+  "ignoreFiles": ["**/node_modules/**", "**/out/**", "/src/styles/**"]
 }

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,4 @@ module.exports = {
       "pixi.js": "pixi.js-legacy",
     },
   },
-  sassOptions: {
-    includePaths: [path.join(__dirname, 'styles')],
-  },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -6,4 +6,7 @@ module.exports = {
       "pixi.js": "pixi.js-legacy",
     },
   },
+  sassOptions: {
+    includePaths: [path.join(__dirname, 'styles')],
+  },
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "pixi.js": "^6.2.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-spring": "^9.3.2"
+    "react-spring": "^9.3.2",
+    "sass": "^1.49.9"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "markuplint": "^1.11.4",
     "react-test-renderer": "^17.0.2",
     "stylelint": "^14.1.0",
-    "stylelint-config-standard": "^24.0.0",
+    "stylelint-config-standard-scss": "^3.0.0",
     "stylelint-order": "^5.0.0",
     "typescript": "4.5.4"
   }

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -16,6 +16,17 @@ textarea {
 }
 
 /**
+ * font
+ */
+/** New Tegomin */
+@import url('https://fonts.googleapis.com/css2?family=New+Tegomin&display=swap');
+/** Noto Sans JP */
+@import url('https://fonts.googleapis.com/css2?family=New+Tegomin&family=Noto+Sans+JP:wght@100&display=swap');
+/** Shippori Mincho */
+@import url('https://fonts.googleapis.com/css2?family=New+Tegomin&family=Noto+Sans+JP:wght@100&family=Shippori+Mincho:wght@500&display=swap');
+
+
+/**
  * variable
  */
 :root {
@@ -44,18 +55,10 @@ textarea {
   --color-darkblue: #2f3846;
   --color-darkblue-lighten: #364051;
   --color-darkblue-darken: #28303c;
-}
 
 /*
  * typography
  */
-/** New Tegomin */
-@import url('https://fonts.googleapis.com/css2?family=New+Tegomin&display=swap');
-/** Noto Sans JP */
-@import url('https://fonts.googleapis.com/css2?family=New+Tegomin&family=Noto+Sans+JP:wght@100&display=swap');
-/** Shippori Mincho */
-@import url('https://fonts.googleapis.com/css2?family=New+Tegomin&family=Noto+Sans+JP:wght@100&family=Shippori+Mincho:wght@500&display=swap');
-
 body {
   margin: 0;
   padding: 0;
@@ -265,5 +268,4 @@ article details > p + p {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
-}
-
+}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6127,6 +6127,11 @@ postcss-safe-parser@^6.0.0:
   resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz#bb4c29894171a94bc5c996b9a30317ef402adaa1"
   integrity sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==
 
+postcss-scss@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-4.0.3.tgz#36c23c19a804274e722e83a54d20b838ab4767ac"
+  integrity sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==
+
 postcss-selector-parser@^6.0.6:
   version "6.0.7"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.7.tgz#48404830a635113a71fd79397de8209ed05a66fc"
@@ -7085,10 +7090,27 @@ styled-jsx@5.0.0-beta.3:
     stylis "3.5.4"
     stylis-rule-sheet "0.0.10"
 
+stylelint-config-recommended-scss@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-5.0.2.tgz#193f483861c76a36ece24c52eb6baca4838f4a48"
+  integrity sha512-b14BSZjcwW0hqbzm9b0S/ScN2+3CO3O4vcMNOw2KGf8lfVSwJ4p5TbNEXKwKl1+0FMtgRXZj6DqVUe/7nGnuBg==
+  dependencies:
+    postcss-scss "^4.0.2"
+    stylelint-config-recommended "^6.0.0"
+    stylelint-scss "^4.0.0"
+
 stylelint-config-recommended@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz#fd2523a322836005ad9bf473d3e5534719c09f9d"
   integrity sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==
+
+stylelint-config-standard-scss@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard-scss/-/stylelint-config-standard-scss-3.0.0.tgz#dafc4fa5538d0ed833bf0a7d391e075683ffd96c"
+  integrity sha512-zt3ZbzIbllN1iCmc94e4pDxqpkzeR6CJo5DDXzltshuXr+82B8ylHyMMARNnUYrZH80B7wgY7UkKTYCFM0UUyw==
+  dependencies:
+    stylelint-config-recommended-scss "^5.0.2"
+    stylelint-config-standard "^24.0.0"
 
 stylelint-config-standard@^24.0.0:
   version "24.0.0"
@@ -7104,6 +7126,17 @@ stylelint-order@^5.0.0:
   dependencies:
     postcss "^8.3.11"
     postcss-sorting "^7.0.1"
+
+stylelint-scss@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-4.1.0.tgz#39b808696f8152081163d970449257ff80b5c041"
+  integrity sha512-BNYTo7MMamhFOlcaAWp2dMpjg6hPyM/FFqfDIYzmYVLMmQJqc8lWRIiTqP4UX5bresj9Vo0dKC6odSh43VP2NA==
+  dependencies:
+    lodash "^4.17.21"
+    postcss-media-query-parser "^0.2.3"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-selector-parser "^6.0.6"
+    postcss-value-parser "^4.1.0"
 
 stylelint@^14.1.0:
   version "14.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2071,6 +2071,21 @@ chokidar@3.5.1:
   optionalDependencies:
     fsevents "~2.3.1"
 
+"chokidar@>=3.0.0 <4.0.0":
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 chokidar@^3.5.0:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
@@ -4058,6 +4073,11 @@ image-size@1.0.0:
   integrity sha512-JLJ6OwBfO1KcA+TvJT+v8gbE6iWbj24LyDNFgFEN0lzegn6cC6a/p3NIDaepMsJjQjlUWqIC7wJv8lBFxPNjcw==
   dependencies:
     queue "6.0.2"
+
+immutable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0.tgz#b86f78de6adef3608395efb269a91462797e2c23"
+  integrity sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -6657,6 +6677,15 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, 
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sass@^1.49.9:
+  version "1.49.9"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.49.9.tgz#b15a189ecb0ca9e24634bae5d1ebc191809712f9"
+  integrity sha512-YlYWkkHP9fbwaFRZQRXgDi3mXZShslVmmo+FVK3kHLUELHHEYrCmL1x6IUjC7wLS6VuJSAFXRQS/DxdsC4xL1A==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+    immutable "^4.0.0"
+    source-map-js ">=0.6.2 <2.0.0"
+
 saxes@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
@@ -6811,6 +6840,11 @@ slice-ansi@^4.0.0:
     ansi-styles "^4.0.0"
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
+
+"source-map-js@>=0.6.2 <2.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 source-map-js@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## 状況

- ローカルでビルドするとnode 14.15.1、16.13.1ともに成功するがnode 16のGitHub Actionsのnode-setupでCSS関連のエラーが出る（node-sassが原因？）
- ログ：https://github.com/RinUeyama/uluhn-the-traveler/runs/5522243447?check_suite_focus=true

## 調査方法

1. Actions側のnodeを14に下げる → [同様のエラー](https://github.com/RinUeyama/uluhn-the-traveler/runs/5522331648?check_suite_focus=true)
2. `uluhn-the-traveler/src/pages/index.module.scss:1:7)` が原因のようなのでぐぐる